### PR TITLE
[Issue 53][PulsarSpout] Adds DLQ support in PulsarSpout of the Storm adaptor

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -71,11 +71,11 @@ jobs:
           distribution: 'adopt'
           java-version: 17
 
-      - name: install org.apache.pulsar.tests:integration:jar:tests:4.0.1
+      - name: install org.apache.pulsar.tests:integration:jar:tests:4.0.2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         run: |
           cd ~
-          git clone --depth 50 --single-branch --branch v4.0.1  https://github.com/apache/pulsar
+          git clone --depth 50 --single-branch --branch v4.0.2  https://github.com/apache/pulsar
           cd pulsar
           mvn -B -ntp -f tests/pom.xml -pl org.apache.pulsar.tests:tests-parent,org.apache.pulsar.tests:integration install
 
@@ -83,10 +83,10 @@ jobs:
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         run: |
           cd ~/pulsar
-          docker pull apachepulsar/pulsar-all:4.0.1
-          docker pull apachepulsar/pulsar:4.0.1
-          docker tag apachepulsar/pulsar-all:4.0.1 apachepulsar/pulsar-all:4.0.1-$(git rev-parse --short=7 HEAD)
-          docker tag apachepulsar/pulsar:4.0.1 apachepulsar/pulsar:4.0.1-$(git rev-parse --short=7 HEAD)
+          docker pull apachepulsar/pulsar-all:4.0.2
+          docker pull apachepulsar/pulsar:4.0.2
+          docker tag apachepulsar/pulsar-all:4.0.2 apachepulsar/pulsar-all:4.0.2-$(git rev-parse --short=7 HEAD)
+          docker tag apachepulsar/pulsar:4.0.2 apachepulsar/pulsar:4.0.2-$(git rev-parse --short=7 HEAD)
           mvn -B -ntp -f tests/docker-images/pom.xml install -pl org.apache.pulsar.tests:latest-version-image -am -Pdocker,-main -DskipTests
 
       - name: run integration tests

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ mvn install
 In order to build this repository the linked Pulsar release must be released to Maven Central
 other wise you have to build it locally.
 
-For instance if this code depends on Pulsar 4.0.1 you have to build Pulsar 4.0.1 locally
+For instance if this code depends on Pulsar 4.0.2 you have to build Pulsar 4.0.2 locally
 
 ```
 git clone https://github.com/apache/pulsar
-git checkout v4.0.1
+git checkout v4.0.2
 mvn clean install -DskipTests
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
   </issueManagement>
 
   <properties>
-    <pulsar.version>4.0.1</pulsar.version>
+    <pulsar.version>4.0.2</pulsar.version>
     <kafka-client.version>2.7.2</kafka-client.version>
     <storm.version>2.0.0</storm.version>
     <kafka_0_8.version>0.8.1.1</kafka_0_8.version>

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
@@ -345,13 +345,7 @@ public class PulsarSpout extends BaseRichSpout implements IMetric {
 
     private boolean mapToValueAndEmit(Message<byte[]> msg) {
         if (msg != null) {
-            Values values;
-            try{
-                values = pulsarSpoutConf.getMessageToValuesMapper().toValues(msg);
-            } catch (Exception e){
-                LOG.error("[{}] Error mapping message to values", msg.getMessageId(), e);
-                return false;
-            }
+            Values values = pulsarSpoutConf.getMessageToValuesMapper().toValues(msg);
             ++pendingAcks;
             if (values == null) {
                 // since the mapper returned null, we can drop the message and

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
@@ -159,14 +159,14 @@ public class PulsarSpout extends BaseRichSpout implements IMetric {
         }
     }
 
-    public void negativeAck(Object msgId) {
-        if (msgId instanceof Message) {
-            Message<?> msg = (Message<?>) msgId;
+    public void negativeAck(Object msg) {
+        if (msg instanceof Message) {
+            Message<?> pulsarMsg = (Message<?>) msg;
             if (LOG.isDebugEnabled()) {
-                LOG.debug("[{}] Received negative ack for message {}", spoutId, msg.getMessageId());
+                LOG.debug("[{}] Received negative ack for message {}", spoutId, pulsarMsg.getMessageId());
             }
-            consumer.negativeAcknowledge(msg);
-            pendingMessageRetries.remove(msg.getMessageId());
+            consumer.negativeAcknowledge(pulsarMsg);
+            pendingMessageRetries.remove(pulsarMsg.getMessageId());
             // we should also remove message from failedMessages but it will be
             // eventually removed while emitting next
             // tuple

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpoutConfiguration.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpoutConfiguration.java
@@ -49,9 +49,11 @@ public class PulsarSpoutConfiguration extends PulsarStormConfiguration {
     private boolean autoUnsubscribe = false;
     private boolean durableSubscription = true;
     // read position if non-durable subscription is enabled : default oldest message available in topic
-    private MessageId nonDurableSubscriptionReadPosition = MessageId.earliest; 
+    private MessageId nonDurableSubscriptionReadPosition = MessageId.earliest;
+    private boolean negativeAckFailedMessages = false;
 
-    
+
+
     /**
      * @return the subscription name for the consumer in the spout
      */
@@ -191,5 +193,22 @@ public class PulsarSpoutConfiguration extends PulsarStormConfiguration {
      */
     public void setNonDurableSubscriptionReadPosition(MessageId nonDurableSubscriptionReadPosition) {
         this.nonDurableSubscriptionReadPosition = nonDurableSubscriptionReadPosition;
+    }
+
+    /**
+     *
+     * @return whether the consumer will negative ack the failed messages
+     */
+    public boolean shouldNegativeAckFailedMessages(){
+        return this.negativeAckFailedMessages;
+    }
+
+    /**
+     * Sets whether the consumer will negative ack the failed messages. <i>(default: false)</i>
+     *
+     * @param negativeAckFailedMessages
+     */
+    public void setNegativeAckFailedMessages(boolean negativeAckFailedMessages){
+        this.negativeAckFailedMessages = negativeAckFailedMessages;
     }
 }

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpoutConsumer.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpoutConsumer.java
@@ -43,6 +43,13 @@ public interface PulsarSpoutConsumer {
     void acknowledgeAsync(Message<?> msg);
 
     /**
+     * Negative ack the message.
+     *
+     * @param msg
+     */
+    void negativeAcknowledge(Message<?> msg);
+
+    /**
      * unsubscribe the consumer
      * @throws PulsarClientException 
      */


### PR DESCRIPTION
Fixes #53

### Motivation
The current implementation of the Storm adaptor does not utilise the dead letter queue functionality of Pulsar. Often it may be desired that when there is some error while processing a message in the Storm topology, the message be moved into the dead letter queue so that it can be handled separately. But the PulsarSpout currently keeps retrying for a while & finally just drops the message by acking it, which leads to data loss. This PR seeks to allow users of PulsarSpout to opt in to using DLQ queues for message processing failures.

### Modifications
1. Added a method `negativeAcknowledge` to the `PulsarSpoutConsumer` interface & added the implementation for the same in the `SpoutConsumer` class.
2. Added a boolean attribute `negativeAckFailedMessages` in the `PulsarSpoutConfiguration` class along with getter & setters for the same.
3. Added a method called `negativeAck` in the `PulsarSpout` class to negatively ack messages and send them to the DLQ.
4. Modified the `fail` method in the `PulsarSpout` class to negatively acknowledge messages when `negativeAckFailedMessages` is set to `true`
5. Modified the `mapToValueAndEmit` method to throw an exception when mapping to the value fails.
6. Updated the version of Pulsar client to `4.0.2`. This is required for this fix as mentioned in the following PR https://github.com/apache/pulsar/pull/23718

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

Tested the cases where `negativeAckFailedMessages` is set to `true` and `false` in the `PulsarSpoutTest` test class.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  yes
  - The public API: yes
  - The schema: don't know
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: bo
  - Anything that affects deployment: don't know

### Documentation

  - Does this pull request introduce a new feature? - yes
  - If yes, how is the feature documented? - I couldn't find the documentation for the pulsar storm adaptor. But I have however, added the javadoc comments to explain the changes wherever necessary.